### PR TITLE
fix 10am/10pm

### DIFF
--- a/src/timezone-converter.coffee
+++ b/src/timezone-converter.coffee
@@ -16,7 +16,7 @@
 moment = require 'moment-timezone'
 chrono = require 'chrono-node'
 
-HUBOT_TIMEZONE_CONVERTER_REGEX  = /(?:1?[1-9][ap]m|(?:1?\d|2[0-3])\:[0-5]\d)/i
+HUBOT_TIMEZONE_CONVERTER_REGEX  = /(?:1?[0-9][ap]m|(?:1?\d|2[0-3])\:[0-5]\d)/i
 HUBOT_TIMEZONE_CONVERTER_FORMAT = process.env.HUBOT_TIMEZONE_CONVERTER_FORMAT or "HH:mm [({tz_label})][\n]"
 
 # Custom Chrono instance, enriched with time zone offset assignment refiner.


### PR DESCRIPTION
it did not recognize 10am or 10pm 😢 Well it doesn't support 10:xx am either or "9 am"

`(2[0-3]|1[0-9]|0?[1-9]):?([0-5]\d)?\s?(am|pm)?` 
would be superior and you can then just use the match groups to see if the first group is larger 13 and ignore if am or pm is set if for some odd reason you don't know when to use am/pm.
https://regex101.com/r/CiyYr2/2
ignore anything that does have two matches.

the first match is the hour, the second match is minutes, the third match is am/pm. Fully supports 9:30 am 👍 